### PR TITLE
Fix repository overview with subversion repositories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Fixed
+- Repository overview which contains subversion repositories ([#4](https://github.com/scm-manager/scm-smeagol-plugin/pull/4))
+
 ## 1.1.0 - 2021-03-18
 ### Added
 - Implement configurable Smeagol link in primary navigation ([#2](https://github.com/scm-manager/scm-smeagol-plugin/pull/2))

--- a/src/main/java/com/cloudogu/smeagol/RepositoryLinkEnricher.java
+++ b/src/main/java/com/cloudogu/smeagol/RepositoryLinkEnricher.java
@@ -51,10 +51,15 @@ public class RepositoryLinkEnricher implements HalEnricher {
   public void enrich(HalEnricherContext context, HalAppender appender) {
     if (configuration.get().isEnabled()) {
       Repository repository = context.oneRequireByType(Repository.class);
-      if (store.getFor(repository).isWikiEnabled()) {
+      if (shouldEnrich(repository)) {
         appender.appendLink("smeagolWiki", createSmeagolUrl(repository));
       }
     }
+  }
+
+  private boolean shouldEnrich(Repository repository) {
+    return SmeagolRepositoryFilter.isPotentiallySmeagolRelevant(repository)
+      && store.getFor(repository).isWikiEnabled();
   }
 
   private String createSmeagolUrl(Repository repository) {

--- a/src/test/java/com/cloudogu/smeagol/RepositoryLinkEnricherTest.java
+++ b/src/test/java/com/cloudogu/smeagol/RepositoryLinkEnricherTest.java
@@ -57,7 +57,7 @@ class RepositoryLinkEnricherTest {
 
   @Test
   void shouldAppendSmeagolLink() {
-    Repository repository = RepositoryTestData.createHeartOfGold();
+    Repository repository = RepositoryTestData.createHeartOfGold("git");
     repository.setId("id-1");
     when(context.oneRequireByType(Repository.class)).thenReturn(repository);
     when(configuration.get()).thenReturn(createConfig(true));
@@ -79,10 +79,21 @@ class RepositoryLinkEnricherTest {
 
   @Test
   void shouldNotAppendSmeagolLinkWhenNotSmeagolRepository() {
-    Repository repository = RepositoryTestData.createHeartOfGold();
+    Repository repository = RepositoryTestData.createHeartOfGold("git");
     when(context.oneRequireByType(Repository.class)).thenReturn(repository);
     when(configuration.get()).thenReturn(createConfig(true));
     when(store.getFor(repository)).thenReturn(new SmeagolRepositoryInformation(repository, new RepositoryInformation("develop", false)));
+
+    enricher.enrich(context, appender);
+
+    verify(appender, never()).appendLink(anyString(), anyString());
+  }
+
+  @Test
+  void shouldNotAppendSmeagolLinkWhenNotSmeagolRelevant() {
+    Repository repository = RepositoryTestData.createHeartOfGold("hg");
+    when(context.oneRequireByType(Repository.class)).thenReturn(repository);
+    when(configuration.get()).thenReturn(createConfig(true));
 
     enricher.enrich(context, appender);
 


### PR DESCRIPTION
## Proposed changes

The repository overview show a 500er if the listing contains a subversion repository. This happens if the smeagol plugins is installed and enabled.

### Your checklist for this pull request

- [X] PR is well described and the description can be used as commit message on squash
- [X] Related issues linked to PR if existing and labels set
- [X] Target branch is not master (in most cases develop should bet the target of choice) 
- [X] Code does not conflict with target branch
- [X] New code is covered with unit tests
- [X] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`
- [X] Definition of Done's fulfilled: [DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/definition-of-done.md) // [UI DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/ui-dod.md)
- [X] Documentation updated (only necessary for new features or changed behaviour)

### Checklist for branch merge request (not required for forks)

- [x] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [x] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
